### PR TITLE
Update permissions on /etc/my.cnf

### DIFF
--- a/proxy-manager/rootfs/etc/fix-attrs.d/permissions
+++ b/proxy-manager/rootfs/etc/fix-attrs.d/permissions
@@ -1,4 +1,5 @@
 /data/mysql true mysql 0644 0755
 /run/mysqld true mysql 0644 0755
+/etc/my.cnf false root 0644 0755
 /run/nginx false root 0644 0755
 /tmp false root 0644 0777


### PR DESCRIPTION
# Proposed Changes

When the container starts up MySQL complains about the file being world writeable and ignores it.


## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/