### PR TITLE
arrow_up Upgrades NGinx Proxy Manager to 2.0.13

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/2.0.12.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/2.0.13.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \

--- a/proxy-manager/rootfs/etc/services.d/manager/run
+++ b/proxy-manager/rootfs/etc/services.d/manager/run
@@ -15,6 +15,10 @@ options+=("--max_old_space_size=250")
 
 export NODE_ENV=production
 
+if bashio::debug; then
+  export DEBUG=1
+fi
+
 cd /opt/nginx-proxy-manager \
     || bashio::exit.nok "Could not change directory to app"
 


### PR DESCRIPTION
# Proposed Changes

## Features
- You can now manually renew a LetsEncrypt cert from the Certificates list
- Added support for DEBUG=1 environment variable to output more verbose info in docker logs
- #85 added LetsEncrypt dns verification support
- #134 more secure SSL ciphers
- Added TLS 1.3 support with an updated nginx version

##Fixes
- Removing a LetsEncrypt cert will now remove it entirely from disk, which means that auto renewals will refresh the correct expiry dates in the database
- #104 Custom locations with / paths are now allowed and the default location won't be used if present
- Fix UI issues with updated tabler interface dependency