### PR TITLE
Fix running addon when using zfs as backing storage

### DIFF
--- a/proxy-manager/rootfs/etc/my.cnf
+++ b/proxy-manager/rootfs/etc/my.cnf
@@ -2,3 +2,7 @@
 symbolic-links=0
 log-output=file
 port=3306
+
+[mysqld]
+innodb=off
+default_storage_engine=Aria


### PR DESCRIPTION
# Proposed Changes

Drop innodb support 

Short story, when using zfs and bind mounts for volumes innodb craps out on creating the ibdata1 file
Because i didn't find any usage of innodb, i think the easiest solution is just disabling i

## Related Issues
https://bugs.alpinelinux.org/issues/9046
<blockquote><img src="/favicon.ico?1554016052" width="48" align="right"><div><strong><a href="https://bugs.alpinelinux.org/issues/9046">Bug #9046: Mariadb 10.2.15-r0 - Alpine Linux - Alpine Linux Development</a></strong></div><div>Redmine</div></blockquote>

https://jira.mariadb.org/browse/MDEV-16015

