### PR TITLE
Add Ingress

### DIFF
--- a/proxy-manager/config.json
+++ b/proxy-manager/config.json
@@ -5,6 +5,8 @@
   "description": "Manage Nginx proxy hosts with a simple, powerful interface",
   "url": "https://github.com/hassio-addons/addon-nginx-proxy-manager",
   "webui": "http://[HOST]:[PORT:81]",
+  "ingress": true,
+  "ingress_port": 81,
   "startup": "application",
   "arch": [
     "aarch64",


### PR DESCRIPTION
Add Ingress Attributes for Access the configuration Interface direct into HA

# Proposed Changes

> Add "ingress": true and "ingress_port": 81 to config.json

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/