### PR TITLE
 Upgrades nginx-proxy-manager to 2.0.14

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -30,7 +30,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/2.0.13.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/2.0.14.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Sorry, commit message is wrong
https://github.com/jc21/nginx-proxy-manager/releases/tag/2.0.14

<blockquote><img src="https://repository-images.githubusercontent.com/114938943/7da8f400-733b-11e9-9132-dd24124cd0ac" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/jc21/nginx-proxy-manager">jc21/nginx-proxy-manager</a></strong></div><div>Docker container for managing Nginx proxy hosts with a simple, powerful interface - jc21/nginx-proxy-manager</div></blockquote>