### PR TITLE
🔨Add gitattributes for us poor Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*. eol=lf
+*.sh eol=lf


### PR DESCRIPTION
# Proposed Changes

Add gitattributes to force LF.  For some reason I am now hitting LF/CRLF issues (I am guessing its to do with the WSL/OpenSSH changes), so would be great if we could add this.  Shouldn't affect anyone else as Linux/Mac will do LF by default.

## Related Issues

None