### PR TITLE
🚑 Fix name resolution via hassio dns

### DIFF
--- a/proxy-manager/rootfs/etc/nginx/conf.d/include/resolvers.conf
+++ b/proxy-manager/rootfs/etc/nginx/conf.d/include/resolvers.conf
@@ -1,2 +1,2 @@
 # Hass.io Resolver
-resolver %%hassio_dns%%;
+resolver %%hassio_dns%% ipv6=off;


### PR DESCRIPTION
# Proposed Changes

Add back ipv6=off flag.

We had this issue previously with the hassio record and getting a servfail response for the ipv6 query.  As users can add anything they want in the proxy host, it would make sense to me to just disable the ipv6 queries for the addon.

## Related Issues

Reported on Discord.

