### PR TITLE
⬆️ Upgrades NGINX Proxy Manager to v2.2.2 and adds option to disable IPv6

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -30,7 +30,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/v2.1.2.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/v2.2.2.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \

--- a/proxy-manager/config.json
+++ b/proxy-manager/config.json
@@ -22,8 +22,11 @@
   "hassio_api": true,
   "hassio_role": "default",
   "map": ["ssl:rw", "backup:rw"],
-  "options": {},
+  "options": {
+    "disable_ipv6": true
+  },
   "schema": {
+    "disable_ipv6": "bool",
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"
   }
 }

--- a/proxy-manager/rootfs/etc/cont-init.d/npm.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/npm.sh
@@ -67,6 +67,11 @@ if ! bashio::fs.directory_exists "/data/nginx/default_host"; then
         /data/nginx/default_www
 fi
 
+# Check if IPv6 is disabled
+if bashio::config.true 'disable_ipv6'; then
+    export DISABLE_IPV6='true'
+fi
+
 # Creates basic temporary files directory structure
 # Needed for caching
 mkdir -p \


### PR DESCRIPTION
# Proposed Changes

Upgrades NGINX Proxy Manager to v2.2.2, which supports disabling IPv6 via ENV: https://nginxproxymanager.com/advanced-config/#disabling-ipv6

fixes #79

Note: I am not familiar with building hassio addons, but as far as I can see, this should add a user facing option to disable IPv6 which is on by default.

<blockquote><img src="https://nginxproxymanager.com/icon.png" width="48" align="right"><div><strong><a href="https://nginxproxymanager.com/">Nginx Proxy Manager</a></strong></div><div>Docker container and built in Web Application for managing Nginx proxy hosts with a simple, powerful interface, providing free SSL support via Let's Encrypt</div></blockquote>