### PR TITLE
✨ Add option to reset database

### DIFF
--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -60,6 +60,14 @@ more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
 
+### Option: `reset_database`
+
+By setting to `true` provides the option to delete and recreate the database. As
+the data is held within the MariaDB addon, it is not removed on an uninstall.
+
+**Note**: _Do not leave this set to `true` for more than one restart, either
+remove or set to false once the database has been reconfigured._
+
 ## Known issues and limitations
 
 - The original NGinx Proxy Manager has support for forwarding TCP/UDP streams,

--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -65,8 +65,8 @@ you are troubleshooting.
 By setting to `true` provides the option to delete and recreate the database. As
 the data is held within the MariaDB addon, it is not removed on an uninstall.
 
-**Note**: _Do not leave this set to `true` for more than one restart, either
-remove or set to false once the database has been reconfigured._
+**Note**: _Once the database is reset the configuration for the addon will be
+cleared automatically_
 
 ## Known issues and limitations
 

--- a/proxy-manager/config.json
+++ b/proxy-manager/config.json
@@ -25,6 +25,7 @@
   "map": ["ssl:rw", "backup:rw"],
   "options": {},
   "schema": {
-    "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"
+    "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
+    "reset_database": "bool?"
   }
 }

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -22,6 +22,14 @@ password=$(bashio::services "mysql" "password")
 port=$(bashio::services "mysql" "port")
 username=$(bashio::services "mysql" "username")
 
+#Drop database based on config flag
+if bashio::config.true 'reset_database'; then
+    bashio::log.warning 'Recreating database, please ensure to edit the'
+    bashio::log.warning 'reset_database configuration flag before restarting'
+    echo "DROP DATABASE IF EXISTS nginxproxymanager;" \
+    | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+fi
+
 # Create database if not exists
 echo "CREATE DATABASE IF NOT EXISTS nginxproxymanager;" \
     | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -24,10 +24,15 @@ username=$(bashio::services "mysql" "username")
 
 #Drop database based on config flag
 if bashio::config.true 'reset_database'; then
-    bashio::log.warning 'Recreating database, please ensure to edit the'
-    bashio::log.warning 'reset_database configuration flag before restarting'
+    bashio::log.warning 'Recreating database'
     echo "DROP DATABASE IF EXISTS nginxproxymanager;" \
     | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+    
+    #Reset addon options to null
+    curl -s -H 'X-Supervisor-Token: '"$SUPERVISOR_TOKEN"'' \
+        -H 'Content-Type: application/json'  \
+            http://supervisor/addons/self/options \
+	    --data-binary '{"options": {}}'
 fi
 
 # Create database if not exists

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -29,10 +29,7 @@ if bashio::config.true 'reset_database'; then
     | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
     
     #Reset addon options to null
-    curl -s -H 'X-Supervisor-Token: '"$SUPERVISOR_TOKEN"'' \
-        -H 'Content-Type: application/json'  \
-            http://supervisor/addons/self/options \
-	    --data-binary '{"options": {}}'
+    bashio::api.supervisor POST "/addons/self/options" '{"options": {}}'
 fi
 
 # Create database if not exists


### PR DESCRIPTION
# Proposed Changes

As the addon is designed to make the Nginx setup simple, it can be confusing that the database is not removed on uninstall.

Adds config option to force the drop of the database if exists.

Also will assist in the cases of lost passwords etc, I did consider adding a backup option prior, but not really sure it would be needed.
