### PR TITLE
:arrow_up: Upgrades NGINX Proxy Manager to v2.8.0

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -40,7 +40,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/v2.7.3.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/v2.8.0.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Release notes:
https://github.com/jc21/nginx-proxy-manager/releases/tag/v2.8.0