### PR TITLE
adding trusted http integration to docs

### DIFF
--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -30,6 +30,20 @@ comparison to installing any other Home Assistant add-on.
 1. Forward port `80` and `443` from your router to your Home Assistant machine.
 1. Enjoy the add-on!
 
+## Home Assistant Configuration
+
+To enable trusted reverse proxies in Home Assistant, you will need to update your `http:` integration.
+In `configuration.yaml`, add the following:
+
+```yaml
+http:
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 172.30.33.3
+    - 127.0.0.1
+    - ::1
+```
+
 ## Configuration
 
 **Note**: _Remember to restart the add-on when the configuration is changed._

--- a/proxy-manager/DOCS.md
+++ b/proxy-manager/DOCS.md
@@ -39,7 +39,7 @@ In `configuration.yaml`, add the following:
 http:
   use_x_forwarded_for: true
   trusted_proxies:
-    - 172.30.33.3
+    - 172.30.33.0/24
     - 127.0.0.1
     - ::1
 ```


### PR DESCRIPTION
# Proposed Changes

> Add section to documentation to clarify adding trusted proxies to Home Assistant config to prevent errors.

## Related Issues

Issue #232 
