### PR TITLE
update proxy manager to v2.9.5.

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -40,7 +40,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/v2.8.1.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/v2.9.5.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \


### PR DESCRIPTION
# Proposed Changes

This pull request updates the used nginx-proxy-manager to version v2.9.5.

## Related Issues

I think #242 is fixed by jc21/nginx-proxy-manager#1081. 

I am new to addon development, and haven't been able to tests the changes. Please test before merge.