### PR TITLE
bumping nginx-proxy-manager version to 2.9.9

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -40,7 +40,7 @@ RUN \
     && yarn global add modclean \
     \
     && curl -J -L -o /tmp/nginxproxymanager.tar.gz \
-        "https://github.com/jc21/nginx-proxy-manager/archive/v2.8.1.tar.gz" \
+        "https://github.com/jc21/nginx-proxy-manager/archive/v2.9.9.tar.gz" \
     && mkdir /app \
     && tar zxvf \
         /tmp/nginxproxymanager.tar.gz \


### PR DESCRIPTION
# Proposed Changes

Using the latest version of nginx-proxy-manager. Should fix a bunch of letsencrypt related issues.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
