### PR TITLE
Migrate add-on to Debian

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:10.0.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base/amd64:5.2.2
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/proxy-manager/build.yaml
+++ b/proxy-manager/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base/aarch64:10.0.1
-  amd64: ghcr.io/hassio-addons/base/amd64:10.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:10.0.1
-  armv7: ghcr.io/hassio-addons/base/armv7:10.0.1
-  i386: ghcr.io/hassio-addons/base/i386:10.0.1
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:5.2.2
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:5.2.2
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:5.2.2
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:5.2.2
+  i386: ghcr.io/hassio-addons/debian-base/i386:5.2.2


### PR DESCRIPTION
# Proposed Changes

To be able to upgrade to the latest NGINX Proxy manager, we need to migrate this add-on from Alpine Linux to Debian Linux.

This PR is here to do just that.
