### PR TITLE
Update letsencrypt.ini to allow for DNS challenge renewals

### DIFF
--- a/proxy-manager/rootfs/etc/letsencrypt.ini
+++ b/proxy-manager/rootfs/etc/letsencrypt.ini
@@ -1,6 +1,5 @@
 text = True
 non-interactive = True
-authenticator = webroot
 webroot-path = /data/letsencrypt-acme-challenge
 logs-dir = /data/logs/letsencrypt
 work-dir = /data/letsencrypt-workdir


### PR DESCRIPTION
# Proposed Changes

Checking through the upstream issue here: https://github.com/NginxProxyManager/nginx-proxy-manager/pull/1286

I find that a single-line change resolves the problem. See here: https://github.com/NginxProxyManager/nginx-proxy-manager/commit/cea80b482ebc5848d7246e7a74f2557384750070

If I console into the addon_1234abcd_nginxproxymanager container as root, I can run the following commands which will allow me to utilize the renew option inside the nginx proxy manager addon:

1. Kill the stuck certbot instance that ran at container start and won't complete due to the change required below: `pkill certbot`
2. Remove the offending line from letsencrypt.ini: `sed -i 's/authenticator = webroot//' /etc/letsencrypt.ini`

And that's it, now the renew function works without error (up until the container restarts anyway, then the old file comes back and the problems begin anew). 

## Related Issues

fixes #258
