### PR TITLE
Suggested solution to issue #365 : Unable to start without MariaDB

### DIFF
--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -8,7 +8,7 @@ declare password
 declare port
 declare username
 
-# Check if a MySQL service is not available
+# If a MySQL service is not available
 # Then log a warning message and continue
 if ! bashio::services.available "mysql"; then
     bashio::log.warning \

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -8,7 +8,8 @@ declare password
 declare port
 declare username
 
-# Check if a MySQL service is available
+# Check if a MySQL service is not available
+# Then log a warning message and continue
 if ! bashio::services.available "mysql"; then
     bashio::log.warning \
         "The MariaDB core add-on (2.0 or newer) is not detected, make sure it is installed and running"

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -8,12 +8,10 @@ declare password
 declare port
 declare username
 
-# Require MySQL service to be available
+# Check if a MySQL service is available
 if ! bashio::services.available "mysql"; then
-    bashio::log.error \
-        "This add-on now requires the MariaDB core add-on 2.0 or newer!"
-    bashio::exit.nok \
-        "Make sure the MariaDB add-on is installed and running"
+    bashio::log.warning \
+        "The MariaDB core add-on (2.0 or newer) is not detected, make sure it is installed and running"
 fi
 
 host=$(bashio::services "mysql" "host")

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,0 @@
-name: Nginx Proxy Manager
-url: https://github.com/nlhomme/addon-nginx-proxy-manager
-maintainer: Nicolas Lhomme <contact@lhomme.xyz>


### PR DESCRIPTION
# Context

As said in issue #365, the MariaDB addons has several issues due to lack of error handling.

During the start of Nginx Proxy Manager, NPM starts a SQLite database if MariaDB cannot be reach.
But this requires that the MariaDB addond is installed and running, even if it cannot be reached by Nginx Proxy Manager.

# Proposed change
If a MySQL service is not available, instead of logging an error message and exit with nok), a warning error and logged and the start process continue

## Related Issues
[Issue 365: Unable to start without MariaDB](https://github.com/hassio-addons/addon-nginx-proxy-manager/issues/365)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
