### PR TITLE
Added support for sqlite database

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -13,16 +13,16 @@ COPY requirements.txt /tmp/
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
-        git=2.36.3-r0 \
+        git=2.36.4-r0 \
         libffi-dev=3.4.2-r1 \
         npm=8.10.0-r0 \
         openssl-dev=1.1.1s-r0 \
         patch=2.7.6-r7 \
-        python3-dev=3.10.8-r0 \
+        python3-dev=3.10.9-r0 \
         yarn=1.22.19-r0 \
     \
     && apk add --no-cache \
-        apache2-utils=2.4.54-r0 \
+        apache2-utils=2.4.55-r0 \
         certbot=1.27.0-r0 \
         libcap=2.64-r0 \
         logrotate=3.19.0-r3 \
@@ -32,7 +32,7 @@ RUN \
         nodejs=16.17.1-r0 \
         openssl=1.1.1s-r0 \
         py3-pip=22.1.1-r0 \
-        python3=3.10.8-r0 \
+        python3=3.10.9-r0 \
     \
     && ln -s /usr/bin/python3 /usr/bin/python \
     \

--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -121,6 +121,9 @@ RUN \
 # Copy root filesystem
 COPY rootfs /
 
+# Set sqlite database name
+ENV DB_SQLITE_FILE  /data/database.sqlite
+
 # Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE

--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -29,9 +29,6 @@ map:
   - backup:rw
 backup_exclude:
   - "*/logs"
-options:
-  use_sqlite: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   reset_database: bool?
-  use_sqlite: bool

--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -13,8 +13,8 @@ arch:
   - armhf
   - armv7
   - i386
-services:
-  - mysql:need
+#services:
+#  - mysql:need
 hassio_api: true
 ports:
   80/tcp: 80
@@ -29,6 +29,9 @@ map:
   - backup:rw
 backup_exclude:
   - "*/logs"
+options:
+  use_sqlite: false
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   reset_database: bool?
+  use_sqlite: bool

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -8,35 +8,48 @@ declare password
 declare port
 declare username
 
-if bashio::config.true 'use_sqlite'; then
-	bashio::log.info 'Sqlite database selected - skipping mysql initialization'
-else
+# return on error
+set -e
 
-	# Require MySQL service to be available
-	if ! bashio::services.available "mysql"; then
-		bashio::log.error \
-			"This add-on now requires the MariaDB core add-on 2.0 or newer!"
-		bashio::exit.nok \
-			"Make sure the MariaDB add-on is installed and running"
-	fi
-
+# Check if MySQL service is available
+if bashio::services.available "mysql"; then
 	host=$(bashio::services "mysql" "host")
 	password=$(bashio::services "mysql" "password")
 	port=$(bashio::services "mysql" "port")
 	username=$(bashio::services "mysql" "username")
 
-	#Drop database based on config flag
-	if bashio::config.true 'reset_database'; then
-		bashio::log.warning 'Recreating database'
+	# Check if nginxproxymanager databse exists
+	if mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}" -e "USE nginxproxymanager"; then 
+		bashio::log.info "mysql database nginxproxymanager exists, trying to convert"; 
+		# Option 1: https://pypi.org/project/mysql-to-sqlite3/
+		# mysql2sqlite -h "${host}" -P "${port}" -u "${username}" --mysql-password "${password}" -f $DB_SQLITE_FILE -V -q		
+		# Option 2: https://github.com/dumblob/mysql2sqlite
+		bashio::log.info "Downloading mysql2sqlite..."
+		wget https://raw.githubusercontent.com/dumblob/mysql2sqlite/master/mysql2sqlite -o /tmp/mysql2sqlite
+		chmod +x /tmp/mysql2sqlite
+		bashio::log.info "Dumping mysql database..."
+		mysqldump --skip-extended-insert --compact -h "${host}" -P "${port}" -u "${username}" -p"${password}" nginxproxymanager > /tmp/dump_mysql.sql
+		bashio::log.info "Converting dump and creating sqlite database..."		
+		/tmp/mysql2sqlite /tmp/dump_mysql.sql | sqlite3 $DB_SQLITE_FILE
+		
+		# Create a backup database in mysql for any case (rename would be easier but seems not to be possible)
+		bashio::log.info "Creating nginxproxymanager.backup database for any case..."
+		mysqladmin -h "${host}" -P "${port}" -u username -p"password" create nginxproxymanager.backup
+		mysql -h "${host}" -P "${port}" -u username -p"password" nginxproxymanager.backup < /tmp/dump_mysql.sql
+		bashio::log.info "If the sqlite database works as expected, please delete nginxproxymanager.backup manually or stop the mysql addon"
+		
+		# Drop database if it exists and conversion was successful		
+		bashio::log.info "Dropping mysql database nginxproxymanager"
 		echo "DROP DATABASE IF EXISTS nginxproxymanager;" \
 		| mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
-
-		#Remove reset_database option
-		bashio::addon.option 'reset_database'
 	fi
+fi
 
-	# Create database if not exists
-	echo "CREATE DATABASE IF NOT EXISTS nginxproxymanager;" \
-		| mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
-
+#Drop database based on config flag
+if bashio::config.true 'reset_database'; then
+	bashio::log.warning 'Recreating database'
+	# remove sqlite file
+	[ -f $DB_SQLITE_FILE ] && rm -f $DB_SQLITE_FILE
+	#Remove reset_database option
+	bashio::addon.option 'reset_database'
 fi

--- a/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/mysql.sh
@@ -8,29 +8,35 @@ declare password
 declare port
 declare username
 
-# Require MySQL service to be available
-if ! bashio::services.available "mysql"; then
-    bashio::log.error \
-        "This add-on now requires the MariaDB core add-on 2.0 or newer!"
-    bashio::exit.nok \
-        "Make sure the MariaDB add-on is installed and running"
+if bashio::config.true 'use_sqlite'; then
+	bashio::log.info 'Sqlite database selected - skipping mysql initialization'
+else
+
+	# Require MySQL service to be available
+	if ! bashio::services.available "mysql"; then
+		bashio::log.error \
+			"This add-on now requires the MariaDB core add-on 2.0 or newer!"
+		bashio::exit.nok \
+			"Make sure the MariaDB add-on is installed and running"
+	fi
+
+	host=$(bashio::services "mysql" "host")
+	password=$(bashio::services "mysql" "password")
+	port=$(bashio::services "mysql" "port")
+	username=$(bashio::services "mysql" "username")
+
+	#Drop database based on config flag
+	if bashio::config.true 'reset_database'; then
+		bashio::log.warning 'Recreating database'
+		echo "DROP DATABASE IF EXISTS nginxproxymanager;" \
+		| mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+
+		#Remove reset_database option
+		bashio::addon.option 'reset_database'
+	fi
+
+	# Create database if not exists
+	echo "CREATE DATABASE IF NOT EXISTS nginxproxymanager;" \
+		| mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+
 fi
-
-host=$(bashio::services "mysql" "host")
-password=$(bashio::services "mysql" "password")
-port=$(bashio::services "mysql" "port")
-username=$(bashio::services "mysql" "username")
-
-#Drop database based on config flag
-if bashio::config.true 'reset_database'; then
-    bashio::log.warning 'Recreating database'
-    echo "DROP DATABASE IF EXISTS nginxproxymanager;" \
-    | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
-
-    #Remove reset_database option
-    bashio::addon.option 'reset_database'
-fi
-
-# Create database if not exists
-echo "CREATE DATABASE IF NOT EXISTS nginxproxymanager;" \
-    | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"

--- a/proxy-manager/rootfs/etc/cont-init.d/npm.sh
+++ b/proxy-manager/rootfs/etc/cont-init.d/npm.sh
@@ -3,11 +3,6 @@
 # Home Assistant Community Add-on: Nginx Proxy Manager
 # This file applies patches so the add-on becomes compatible
 # ==============================================================================
-declare mysql_host
-declare mysql_password
-declare mysql_port
-declare mysql_username
-declare query
 
 # Redirect log output to the add-on log
 sed -i 's#/data/logs/fallback_error.log#/proc/1/fd/1#g' /etc/nginx/nginx.conf
@@ -62,9 +57,6 @@ fi
 
 if ! bashio::fs.directory_exists "/data/manager"; then
     mkdir /data/manager
-    if bashio::config.false 'use_sqlite'; then
-      cp /defaults/production.json /data/manager/production.json
-    fi
 fi
 
 if ! bashio::fs.directory_exists "/ssl/nginxproxymanager"; then
@@ -127,23 +119,4 @@ then
     -keyout /data/nginx/dummykey.pem \
     -out /data/nginx/dummycert.pem \
     || bashio::exit.nok "Could not generate dummy certificate"
-fi
-
-if bashio::config.false 'use_sqlite'; then
-    # Set up database connection
-    mysql_host=$(bashio::services "mysql" "host")
-    mysql_password=$(bashio::services "mysql" "password")
-    mysql_port=$(bashio::services "mysql" "port")
-    mysql_username=$(bashio::services "mysql" "username")
-
-    query=".database.engine = \"mysql\"
-        | .database.host = \"${mysql_host}\"
-        | .database.name = \"nginxproxymanager\"
-        | .database.user = \"${mysql_username}\"
-        | .database.password = \"${mysql_password}\"
-        | .database.port = ${mysql_port}"
-
-    # shellcheck disable=SC2094
-    cat <<< "$(jq "${query}" /data/manager/production.json)" \
-        > /data/manager/production.json
 fi


### PR DESCRIPTION
# Proposed Changes

> I'd like to use the sqlite database that is also supported by the proxy manager. An additional config variable is used to activate it.

## Related Issues

> #386 and #368

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
