### PR TITLE
Fix NPM build with NodeJS 18x

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -2,6 +2,9 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base:13.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
+# Required for webpack config of NPM
+ENV NODE_OPTIONS="--openssl-legacy-provider"
+
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
# Proposed Changes

Temporary workaround to get Webpack building in NodeJS 18.x (as configured in NPM).
