### PR TITLE
Update all blockers for hassio-addons/base:14.3.1 in order to update nginx-proxy-manager to v2.10.4 due to CVE

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:14.3.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:14.3.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -20,7 +20,7 @@ RUN \
         git=2.40.1-r0 \
         libffi-dev=3.4.4-r2 \
         npm=9.6.6-r0 \
-        openssl-dev=3.1.3-r0 \
+        openssl-dev=3.1.4-r0 \
         patch=2.7.6-r10 \
         python3-dev=3.11.6-r0 \
         yarn=1.22.19-r0 \
@@ -33,7 +33,7 @@ RUN \
         nginx-mod-stream=1.24.0-r7 \
         nginx=1.24.0-r7 \
         nodejs=18.18.2-r0 \
-        openssl=3.1.3-r0 \
+        openssl=3.1.4-r0 \
         py3-pip=23.1.2-r0 \
         python3=3.11.6-r0 \
     \

--- a/proxy-manager/build.yaml
+++ b/proxy-manager/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:14.3.0
-  amd64: ghcr.io/hassio-addons/base:14.3.0
-  armhf: ghcr.io/hassio-addons/base:14.3.0
-  armv7: ghcr.io/hassio-addons/base:14.3.0
-  i386: ghcr.io/hassio-addons/base:14.3.0
+  aarch64: ghcr.io/hassio-addons/base:14.3.1
+  amd64: ghcr.io/hassio-addons/base:14.3.1
+  armhf: ghcr.io/hassio-addons/base:14.3.1
+  armv7: ghcr.io/hassio-addons/base:14.3.1
+  i386: ghcr.io/hassio-addons/base:14.3.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/proxy-manager/requirements.txt
+++ b/proxy-manager/requirements.txt
@@ -1,1 +1,1 @@
-certbot-dns-cloudflare==2.7.2
+certbot-dns-cloudflare==2.7.3


### PR DESCRIPTION
# Proposed Changes

Updated build base to hassio-addons/base to 14.3.1 hassio-addons/addon-nginx-proxy-manager#484

Updated openssl to 3.1.4-r0 due to 3.1.3-r0 being broken in hassio-addons/base:14.3.1 hassio-addons/addon-nginx-proxy-manager#484 hassio-addons/addon-nginx-proxy-manager#482

Updated certbot-dns-cloudflare to v2.7.3 hassio-addons/addon-nginx-proxy-manager#483

## Related Issues

Updated to resolve [CVE-2023-27224](https://www.cvedetails.com/cve/CVE-2023-27224/) hassio-addons/addon-nginx-proxy-manager#470
