### PR TITLE
Patch certbot plugin handling

### DIFF
--- a/proxy-manager/patches/0004-patch-certbot-venv-plugin-handling.patch
+++ b/proxy-manager/patches/0004-patch-certbot-venv-plugin-handling.patch
@@ -1,0 +1,39 @@
+From 6aa422ca2dd2f00ca9fd105cc29e7e2649566e43 Mon Sep 17 00:00:00 2001
+From: Franck Nijhof <git@frenck.dev>
+Date: Sat, 13 Jan 2024 10:19:57 +0100
+Subject: [PATCH] Patch npm certbot venv plugin handling
+
+---
+ backend/internal/certificate.js | 2 +-
+ backend/setup.js                | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/backend/internal/certificate.js b/backend/internal/certificate.js
+index 871a280..f1a667b 100644
+--- a/backend/internal/certificate.js
++++ b/backend/internal/certificate.js
+@@ -877,7 +877,7 @@ const internalCertificate = {
+ 		const escapedCredentials = certificate.meta.dns_provider_credentials.replaceAll('\'', '\\\'').replaceAll('\\', '\\\\');
+ 		const credentialsCmd     = 'mkdir -p /etc/letsencrypt/credentials 2> /dev/null; echo \'' + escapedCredentials + '\' > \'' + credentialsLocation + '\' && chmod 600 \'' + credentialsLocation + '\'';
+ 		// we call `. /opt/certbot/bin/activate` (`.` is alternative to `source` in dash) to access certbot venv
+-		const prepareCmd = '. /opt/certbot/bin/activate && pip install --no-cache-dir ' + dns_plugin.package_name + (dns_plugin.version_requirement || '') + ' ' + dns_plugin.dependencies + ' && deactivate';
++		const prepareCmd = 'pip install ' + dns_plugin.package_name + (dns_plugin.version_requirement || '') + ' ' + dns_plugin.dependencies;
+ 
+ 		// Whether the plugin has a --<name>-credentials argument
+ 		const hasConfigArg = certificate.meta.dns_provider !== 'route53';
+diff --git a/backend/setup.js b/backend/setup.js
+index 403c14e..7451271 100644
+--- a/backend/setup.js
++++ b/backend/setup.js
+@@ -131,7 +131,7 @@ const setupCertbotPlugins = () => {
+ 				});
+ 
+ 				if (plugins.length) {
+-					const install_cmd = '. /opt/certbot/bin/activate && pip install --no-cache-dir ' + plugins.join(' ') + ' && deactivate';
++					const install_cmd = 'pip install ' + plugins.join(' ')';
+ 					promises.push(utils.exec(install_cmd));
+ 				}
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
# Proposed Changes

Patches the behavior of how NPM installs plugins for certbot. It tries to do so in an venv, however, we are already isolated here and we don't have certbot in an venv.