### PR TITLE
Fix syntax error in certbot patch

### DIFF
--- a/proxy-manager/patches/0004-patch-certbot-venv-plugin-handling.patch
+++ b/proxy-manager/patches/0004-patch-certbot-venv-plugin-handling.patch
@@ -30,7 +30,7 @@ index 403c14e..7451271 100644
  
  				if (plugins.length) {
 -					const install_cmd = '. /opt/certbot/bin/activate && pip install --no-cache-dir ' + plugins.join(' ') + ' && deactivate';
-+					const install_cmd = 'pip install ' + plugins.join(' ')';
++					const install_cmd = 'pip install ' + plugins.join(' ');
  					promises.push(utils.exec(install_cmd));
  				}
  


### PR DESCRIPTION
# Proposed Changes

Fixes a stupid and shameful syntax error I've introduced in the last patch.

While that patch was tested and worked for existing installations, it did break the setup for new installations (which people are experiencing when upgrade to add-on v1).

As reported in #507 

Confirmed this change makes installations in the reported error state work (manually patched 2 systems on which I've been able to reproduce the reported issue).