### PR TITLE
Support using externally configured SSL certificates from HA

### DIFF
--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -18,5 +18,6 @@ ports:
   443/tcp: 443
 map:
   - addon_config:rw
+  - ssl:ro
 backup_exclude:
   - "*/logs"


### PR DESCRIPTION
# Proposed Changes

Proposed here is the ability for the NGINX Proxy Manager addon to reuse an existing SSL certificate created and managed outside of its context, such as with HA's Lets Encrypt addon. The intention is people will use their own SSL directives in custom server blocks to access the cert since upstream nginx-proxy-manager doesn't support on-disk certs currently. Whenever it does though no changes would be needed here.

Why is this needed instead of using the built-in certificate generation? I have multiple addons in HA that share a certificate directory and I don't want to issue multiple certificates for services on the same hardware/OS.

## Related Issues

didn't see any

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Introduced a new read-only SSL configuration option to enhance security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->