### PR TITLE
Bump transitive dependencies to fix CI

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base-nodejs:0.2.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/base-nodejs:0.2.5
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -16,13 +16,16 @@ COPY patches/*.patch /usr/src/
 ARG NGINX_PROXY_MANAGER_VERSION="v2.10.4"
 # hadolint ignore=DL3003,DL3042
 RUN \
+    apk add --no-cache \
+        libcrypto3=3.1.7-r1 \
+        libssl3=3.1.7-r1 && \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
         git=2.43.5-r0 \
         libffi-dev=3.4.4-r3 \
-        openssl-dev=3.1.7-r0 \
+        openssl-dev=3.1.7-r1 \
         patch=2.7.6-r10 \
-        python3-dev=3.11.10-r0 \
+        python3-dev=3.11.11-r0 \
     \
     && apk add --no-cache \
         apache2-utils=2.4.62-r0 \
@@ -31,9 +34,9 @@ RUN \
         logrotate=3.21.0-r1 \
         nginx-mod-stream=1.24.0-r16 \
         nginx=1.24.0-r16 \
-        openssl=3.1.7-r0 \
+        openssl=3.1.7-r1 \
         py3-pip=23.3.1-r0 \
-        python3=3.11.10-r0 \
+        python3=3.11.11-r0 \
     \
     && pip3 install -r /tmp/requirements.txt \
     \

--- a/proxy-manager/requirements.txt
+++ b/proxy-manager/requirements.txt
@@ -1,1 +1,1 @@
-certbot-dns-cloudflare==2.10.0
+certbot-dns-cloudflare==2.11.0


### PR DESCRIPTION
This attempts to fix CI by bumping all kinds of dependencies at once. I'm avoiding bumping Nginx Proxy Manager for now because the patches in this repository do not apply cleanly to its latest version.

Ref. https://github.com/hassio-addons/addon-base-nodejs/pull/28

closes #609
closes #607
closes #606
closes #578
closes #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new package, `libcrypto3`.
  
- **Bug Fixes**
	- Updated various package versions to improve stability and security, including `openssl-dev`, `python3-dev`, `openssl`, and `python3`.

- **Documentation**
	- Updated dependency version for `certbot-dns-cloudflare` to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->