### PR TITLE
Set startup option in add-on config to "services"

### DIFF
--- a/proxy-manager/config.yaml
+++ b/proxy-manager/config.yaml
@@ -6,6 +6,7 @@ description: Manage Nginx proxy hosts with a simple, powerful interface
 url: https://github.com/hassio-addons/addon-nginx-proxy-manager
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:81]
+startup: services
 init: false
 arch:
   - aarch64


### PR DESCRIPTION
# Proposed Changes

Set startup option in addon config to "services".

This will allow the addon to not wait for Home Assistant to start, which is especially helpful if Home Assistant itself is being proxied by NPM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for startup behavior in the Nginx Proxy Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->