### PR TITLE
Workaround NPM cloudflare bug

### DIFF
--- a/proxy-manager/Dockerfile
+++ b/proxy-manager/Dockerfile
@@ -8,8 +8,7 @@ ENV NODE_OPTIONS="--openssl-legacy-provider"
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Copy Python requirements file & patches
-COPY requirements.txt /tmp/
+# Copy patches
 COPY patches/*.patch /usr/src/
 
 # Setup base
@@ -37,8 +36,6 @@ RUN \
         py3-pip=25.1.1-r0 \
         python3=3.12.11-r0 \
         yarn=1.22.22-r1 \
-    \
-    && pip3 install -r /tmp/requirements.txt \
     \
     && yarn global add modclean \
     \

--- a/proxy-manager/patches/0006-fix-cloudflare-dependency-conflict.patch
+++ b/proxy-manager/patches/0006-fix-cloudflare-dependency-conflict.patch
@@ -1,0 +1,23 @@
+Changes cloudflare package version from 4.0.* to 2.19.* (without pinning it)
+to resolve dependency conflict with certbot-dns-cloudflare in NPM 2.12.4.
+
+Fixes: https://github.com/hassio-addons/addon-nginx-proxy-manager/issues/658
+---
+ global/certbot-dns-plugins.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/global/certbot-dns-plugins.json b/global/certbot-dns-plugins.json
+index 1234567..abcdefg 100644
+--- a/global/certbot-dns-plugins.json
++++ b/global/certbot-dns-plugins.json
+@@ -67,7 +67,7 @@
+ 		"name": "Cloudflare",
+ 		"package_name": "certbot-dns-cloudflare",
+ 		"version": "=={{certbot-version}}",
+-		"dependencies": "cloudflare==4.0.* acme=={{certbot-version}}",
++		"dependencies": "cloudflare acme=={{certbot-version}}",
+ 		"credentials": "# Cloudflare API credentials used by Certbot\ndns_cloudflare_email = cloudflare@example.com\ndns_cloudflare_api_key = 0123456789abcdef0123456789abcdef01234",
+ 		"full_plugin_name": "dns-cloudflare"
+ 	},
+--
+2.42.0

--- a/proxy-manager/requirements.txt
+++ b/proxy-manager/requirements.txt
@@ -1,1 +1,0 @@
-certbot-dns-cloudflare==4.1.1


### PR DESCRIPTION
# Proposed Changes

Temporarly introduces a patch to work around a dependency conflict in the latest NGINX Proxy Manager version.



## Related Issues

fixes #658
fixes #660

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a dependency conflict with the Cloudflare package in the certbot-dns-cloudflare plugin.

* **Chores**
  * Removed installation of Python dependencies during image build.
  * Removed certbot-dns-cloudflare from the list of required dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->