### PR TITLE
Re-enable IPv6 support, now Supervisor added support as well

### DIFF
--- a/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/npm/run
+++ b/proxy-manager/rootfs/etc/s6-overlay/s6-rc.d/npm/run
@@ -17,8 +17,6 @@ if bashio::debug; then
   export DEBUG=1
 fi
 
-# IPv6 is currently not supported yet on a Supervisor enabled system.
-export DISABLE_IPV6="true"
 
 cd /opt/nginx-proxy-manager \
     || bashio::exit.nok "Could not change directory to app"


### PR DESCRIPTION
# Proposed Changes

Re-enabled IPv6 support.

## Related Issues

closes https://github.com/hassio-addons/addon-nginx-proxy-manager/issues/654

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system configuration to remove settings related to IPv6 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->